### PR TITLE
chore: migrate CI workflows to self-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, geiserback]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, geiserback]
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, geiserback]
     steps:
       - uses: actions/stale@v9
         with:


### PR DESCRIPTION
## Summary
- Migrate `ci.yml`, `docker-publish.yml`, and `stale.yml` from `ubuntu-latest` to `[self-hosted, Linux, X64, geiserback]`
- `dockerhub-description.yml` remains on `ubuntu-latest` (no local tooling needed)
- No additional setup actions required: `ci.yml` already has `setup-go`, Docker workflows use self-contained actions, and `stale.yml` only calls the GitHub API

## Test plan
- [ ] Verify CI workflow runs on self-hosted runner and passes tests
- [ ] Verify Docker publish workflow builds and pushes image on tag push
- [ ] Verify stale workflow triggers on schedule