### PR TITLE
ci(dependabot): allow github-actions major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,67 +1,63 @@
 version: 2
 updates:
-- package-ecosystem: gomod
-  directory: /
-  schedule:
-    interval: weekly
-    day: monday
-  commit-message:
-    prefix: deps
-  labels:
-  - dependencies
-  - automated
-  groups:
-    minor-and-patch:
-      patterns:
-      - '*'
-      update-types:
-      - minor
-      - patch
-    gomod_security:
-      applies-to: security-updates
-      patterns:
-      - '*'
-  ignore:
-  - dependency-name: '*'
-    update-types:
-    - version-update:semver-major
-- package-ecosystem: docker
-  directory: /
-  schedule:
-    interval: weekly
-    day: monday
-  commit-message:
-    prefix: docker
-  labels:
-  - docker
-  - automated
-  groups:
-    docker_security:
-      applies-to: security-updates
-      patterns:
-      - '*'
-- package-ecosystem: github-actions
-  directory: /
-  schedule:
-    interval: monthly
-  open-pull-requests-limit: 10
-  commit-message:
-    prefix: ci
-  labels:
-  - ci
-  - automated
-  groups:
-    minor-and-patch:
-      patterns:
-      - '*'
-      update-types:
-      - minor
-      - patch
-    github-actions-security:
-      applies-to: security-updates
-      patterns:
-      - '*'
-  ignore:
-  - dependency-name: '*'
-    update-types:
-    - version-update:semver-major
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    commit-message:
+      prefix: deps
+    labels:
+      - dependencies
+      - automated
+    groups:
+      minor-and-patch:
+        patterns:
+          - '*'
+        update-types:
+          - minor
+          - patch
+      gomod_security:
+        applies-to: security-updates
+        patterns:
+          - '*'
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - version-update:semver-major
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    commit-message:
+      prefix: docker
+    labels:
+      - docker
+      - automated
+    groups:
+      docker_security:
+        applies-to: security-updates
+        patterns:
+          - '*'
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: ci
+    labels:
+      - ci
+      - automated
+    groups:
+      minor-and-patch:
+        patterns:
+          - '*'
+        update-types:
+          - minor
+          - patch
+      github-actions-security:
+        applies-to: security-updates
+        patterns:
+          - '*'


### PR DESCRIPTION
Removes the `semver-major` ignore from the `github-actions` ecosystem so action major upgrades stop silently drifting. npm/docker majors remain gated.

Auto-merge enabled; merges on green CI.